### PR TITLE
🩹 [Patch]: Make PS5.1 compatible

### DIFF
--- a/src/PATH/public/Get-EnvironmentPath.ps1
+++ b/src/PATH/public/Get-EnvironmentPath.ps1
@@ -40,7 +40,7 @@
     if (-not $AsArray) {
         return $environmentPath
     }
-    if ($IsWindows) {
+    if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
         $pathSeparator = ';'
     } else {
         $pathSeparator = ':'

--- a/src/PATH/public/Remove-EnvironmentPath.ps1
+++ b/src/PATH/public/Remove-EnvironmentPath.ps1
@@ -104,7 +104,7 @@ Please run the command again with elevated rights (Run as Administrator) or prov
     }
 
     end {
-        if ($IsWindows) {
+        if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
             $pathSeparator = ';'
         } else {
             $pathSeparator = ':'

--- a/src/PATH/public/Repair-EnvironmentPath.ps1
+++ b/src/PATH/public/Repair-EnvironmentPath.ps1
@@ -98,7 +98,7 @@ Please run the command again with elevated rights (Run as Administrator) or prov
     }
 
     end {
-        if ($IsWindows) {
+        if ([System.Environment]::OSVersion.Platform -eq 'Win32NT') {
             $pathSeparator = ';'
         } else {
             $pathSeparator = ':'


### PR DESCRIPTION
## Description

- Make PS5.1 compatible, by not using `$IsWindows`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
