### PR TITLE
🩹 [Patch]: Enable publishing docs to GitHub Pages

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -21,10 +21,12 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
+  pages: write
+  id-token: write
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v1
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v2
     secrets: inherit
     with:
       SkipTests: Linux, macOS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,75 @@
+site_name: -{{ REPO_NAME }}-
+theme:
+  name: material
+  language: en
+  font:
+    text: Roboto
+    code: Sono
+  logo: Assets/icon.png
+  favicon: Assets/icon.png
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/link
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      toggle:
+        primary: black
+        accent: green
+        icon: material/toggle-switch-off-outline
+        name: Switch to light mode
+    # Palette toggle for light mode
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      toggle:
+        primary: indigo
+        accent: green
+        icon: material/toggle-switch
+        name: Switch to system preference
+  icon:
+    repo: material/github
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.indexes
+    - navigation.top
+    - navigation.tracking
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+
+repo_name: -{{ REPO_OWNER }}-/-{{ REPO_NAME }}-
+repo_url: https://github.com/-{{ REPO_OWNER }}-/-{{ REPO_NAME }}-
+
+plugins:
+  - search
+
+markdown_extensions:
+  - toc:
+      permalink: true # Adds a link icon to headings
+  - attr_list
+  - admonition
+  - md_in_html
+  - pymdownx.details # Enables collapsible admonitions
+
+extra:
+  social:
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/jedJWCPAhD
+      name: -{{ REPO_OWNER }}- on Discord
+    - icon: fontawesome/brands/github
+      link: https://github.com/-{{ REPO_OWNER }}-/
+      name: -{{ REPO_OWNER }}- on GitHub
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.
+    actions:
+      - accept
+      - reject


### PR DESCRIPTION
## Description

- Bump Process-PSModule to v2
- Add pages and id-token permissions
- Add mkdocs.yml settings file

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
