### PR TITLE
🩹 [Patch]: Update linter and git configurations and license year

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,10 @@
+{
+    "threshold": 0,
+    "reporters": [
+        "consoleFull"
+    ],
+    "ignore": [
+        "**/tests/**"
+    ],
+    "absolute": true
+}

--- a/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -1,17 +1,56 @@
-﻿#Documentation: https://github.com/PowerShell/PSScriptAnalyzer/blob/master/docs/Cmdlets/Invoke-ScriptAnalyzer.md#-settings
-@{
-    #CustomRulePath='path\to\CustomRuleModule.psm1'
-    #RecurseCustomRulePath='path\of\customrules'
-    #Severity = @(
-    #    'Error'
-    #    'Warning'
-    #)
-    #IncludeDefaultRules=${true}
+﻿@{
+    Rules        = @{
+        PSAlignAssignmentStatement         = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+        PSAvoidLongLines                   = @{
+            Enable            = $true
+            MaximumLineLength = 150
+        }
+        PSAvoidSemicolonsAsLineTerminators = @{
+            Enable = $true
+        }
+        PSPlaceCloseBrace                  = @{
+            Enable             = $true
+            NewLineAfter       = $false
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+        PSPlaceOpenBrace                   = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+        PSProvideCommentHelp               = @{
+            Enable                  = $true
+            ExportedOnly            = $false
+            BlockComment            = $true
+            VSCodeSnippetCorrection = $false
+            Placement               = 'begin'
+        }
+        PSUseConsistentIndentation         = @{
+            Enable              = $true
+            IndentationSize     = 4
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            Kind                = 'space'
+        }
+        PSUseConsistentWhitespace          = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $true
+            CheckSeparator                          = $true
+            CheckParameter                          = $true
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+    }
     ExcludeRules = @(
-        'PSMissingModuleManifestField'
+        'PSMissingModuleManifestField', # This rule is not applicable until the module is built.
+        'PSUseToExportFieldsInManifest'
     )
-    #IncludeRules = @(
-    #    'PSAvoidUsingWriteHost',
-    #    'MyCustomRuleName'
-    #)
 }

--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -1,0 +1,513 @@
+{
+    "filters": {
+        "comments": true
+    },
+    "rules": {
+        "terminology": {
+            "defaultTerms": false,
+            "terms": [
+                "Airbnb",
+                "Android",
+                "AppleScript",
+                "AppVeyor",
+                "AVA",
+                "BrowserStack",
+                "Browsersync",
+                "Codecov",
+                "CodePen",
+                "CodeSandbox",
+                "DefinitelyTyped",
+                "EditorConfig",
+                "ESLint",
+                "GitHub",
+                "GraphQL",
+                "GraphiQL",
+                "iOS",
+                "JavaScript",
+                "JetBrains",
+                "jQuery",
+                "LinkedIn",
+                "Lodash",
+                "MacBook",
+                "Markdown",
+                "OpenType",
+                "PayPal",
+                "PhpStorm",
+                "PowerShell",
+                "PlayStation",
+                "RubyMine",
+                "Sass",
+                "SemVer",
+                "TypeScript",
+                "UglifyJS",
+                "Wasm",
+                "WebAssembly",
+                "WebStorm",
+                "WordPress",
+                "YouTube",
+                [
+                    "Common[ .]js",
+                    "CommonJS"
+                ],
+                [
+                    "JSDocs?",
+                    "JSDoc"
+                ],
+                [
+                    "Node[ .]js",
+                    "Node.js"
+                ],
+                [
+                    "React[ .]js",
+                    "React"
+                ],
+                [
+                    "SauceLabs",
+                    "Sauce Labs"
+                ],
+                [
+                    "StackOverflow",
+                    "Stack Overflow"
+                ],
+                [
+                    "styled ?components",
+                    "styled-components"
+                ],
+                [
+                    "HTTP[ /]2(?:\\.0)?",
+                    "HTTP/2"
+                ],
+                [
+                    "OS X",
+                    "macOS"
+                ],
+                [
+                    "Mac ?OS",
+                    "macOS"
+                ],
+                [
+                    "a npm",
+                    "an npm"
+                ],
+                "ECMAScript",
+                [
+                    "ES2015",
+                    "ES6"
+                ],
+                [
+                    "ES7",
+                    "ES2016"
+                ],
+                "3D",
+                [
+                    "3-D",
+                    "3D"
+                ],
+                "Ajax",
+                "API",
+                "APIs",
+                "API's",
+                [
+                    "(?<!\\.)css\\b",
+                    "CSS"
+                ],
+                [
+                    "(?<!\\.)gif\\b",
+                    "GIF"
+                ],
+                [
+                    "(?<!\\.)html\\b",
+                    "HTML"
+                ],
+                "HTTPS",
+                "IoT",
+                "I/O",
+                [
+                    "I-O",
+                    "I/O"
+                ],
+                [
+                    "(?<!\\.)jpeg\\b",
+                    "JPEG"
+                ],
+                "MIME",
+                "OK",
+                "PaaS",
+                [
+                    "(?<!\\.)pdf\\b",
+                    "PDF"
+                ],
+                [
+                    "(?<!\\.)png\\b",
+                    "PNG"
+                ],
+                "SaaS",
+                "URL",
+                [
+                    "URL['’]?s",
+                    "URLs"
+                ],
+                [
+                    "an URL",
+                    "a URL"
+                ],
+                [
+                    "wi[- ]?fi",
+                    "Wi-Fi"
+                ],
+                "ZIP",
+                "McKenzie",
+                "McConnell",
+                "ID",
+                [
+                    "id['’]?s",
+                    "IDs"
+                ],
+                [
+                    "backwards compatible",
+                    "backward compatible"
+                ],
+                [
+                    "build system(s)?",
+                    "build tool$1"
+                ],
+                [
+                    "CLI tool(s)?",
+                    "command-line tool$1"
+                ],
+                [
+                    "he or she",
+                    "they"
+                ],
+                [
+                    "he/she",
+                    "they"
+                ],
+                [
+                    "\\(s\\)he",
+                    "they"
+                ],
+                [
+                    "smartphone(s)?",
+                    "mobile phone$1"
+                ],
+                [
+                    "spread operator",
+                    "spread syntax"
+                ],
+                [
+                    "web[- ]?site(s)?",
+                    "site$1"
+                ],
+                [
+                    "auto[- ]complete",
+                    "autocomplete"
+                ],
+                [
+                    "auto[- ]format",
+                    "autoformat"
+                ],
+                [
+                    "auto[- ]fix",
+                    "autofix"
+                ],
+                [
+                    "auto[- ]fixing",
+                    "autofixing"
+                ],
+                [
+                    "back[- ]end(\\w*)",
+                    "backend$1"
+                ],
+                [
+                    "bug[- ]fix(es)?",
+                    "bugfix$1"
+                ],
+                [
+                    "change[- ]log(s)?",
+                    "changelog$1"
+                ],
+                [
+                    "check[- ]box(es)?",
+                    "checkbox$1"
+                ],
+                [
+                    "code[- ]base(es)?",
+                    "codebase$1"
+                ],
+                [
+                    "co[- ]locate(d?)",
+                    "colocate$1"
+                ],
+                [
+                    "end[- ]point(s)?",
+                    "endpoint$1"
+                ],
+                [
+                    "e[- ]mail(s)?",
+                    "email$1"
+                ],
+                [
+                    "file[- ]name(s)?",
+                    "filename$1"
+                ],
+                [
+                    "front[- ]end(\\w*)",
+                    "frontend$1"
+                ],
+                [
+                    "hack[- ]a[- ]thon(s)?",
+                    "hackathon$1"
+                ],
+                [
+                    "host[- ]name(s)?",
+                    "hostname$1"
+                ],
+                [
+                    "hot[- ]key(s)?",
+                    "hotkey$1"
+                ],
+                [
+                    "life[- ]cycle",
+                    "lifecycle"
+                ],
+                [
+                    "life[- ]stream(s)?",
+                    "lifestream$1"
+                ],
+                [
+                    "lock[- ]file(s)?",
+                    "lockfile$1"
+                ],
+                [
+                    "mark-up",
+                    "markup"
+                ],
+                [
+                    "meta[- ]data",
+                    "metadata"
+                ],
+                [
+                    "micro[- ]service(s)?",
+                    "microservice$1"
+                ],
+                [
+                    "name[- ]space(s)?",
+                    "namespace$1"
+                ],
+                [
+                    "pre[- ]condition(s)?",
+                    "precondition$1"
+                ],
+                [
+                    "pre[- ]defined",
+                    "predefined"
+                ],
+                [
+                    "pre[- ]release(s)?",
+                    "prerelease$1"
+                ],
+                [
+                    "re[- ]write",
+                    "rewrite"
+                ],
+                [
+                    "run[- ]time",
+                    "runtime"
+                ],
+                [
+                    "screen[- ]shot(s)?",
+                    "screenshot$1"
+                ],
+                [
+                    "screen[- ]?snap(s)?",
+                    "screenshot$1"
+                ],
+                [
+                    "sub[- ]class((?:es|ing)?)",
+                    "subclass$1"
+                ],
+                [
+                    "sub[- ]tree(s)?",
+                    "subtree$1"
+                ],
+                [
+                    "time[- ]stamp(s)?",
+                    "timestamp$1"
+                ],
+                [
+                    "touch[- ]screen(s)?",
+                    "touchscreen$1"
+                ],
+                [
+                    "user[- ]name(s)?",
+                    "username$1"
+                ],
+                [
+                    "walk-through",
+                    "walkthrough"
+                ],
+                [
+                    "white[- ]space",
+                    "whitespace"
+                ],
+                [
+                    "wild[- ]card(s)?",
+                    "wildcard$1"
+                ],
+                [
+                    "css-?in-?js",
+                    "CSS in JS"
+                ],
+                [
+                    "code-?review(s)?",
+                    "code review$1"
+                ],
+                [
+                    "code-?splitting",
+                    "code splitting"
+                ],
+                [
+                    "end-?user(s)?",
+                    "end user$1"
+                ],
+                [
+                    "file-?type(s)?",
+                    "file type$1"
+                ],
+                [
+                    "micro-?frontend(s)?",
+                    "micro frontend$1"
+                ],
+                [
+                    "open-?source(ed?)",
+                    "open source$1"
+                ],
+                [
+                    "regexp?(s)?",
+                    "regular expression$1"
+                ],
+                [
+                    "style-?guide(s)?",
+                    "style guide$1"
+                ],
+                [
+                    "tree-?shaking",
+                    "tree shaking"
+                ],
+                [
+                    "source-?map(s)?",
+                    "source map$1"
+                ],
+                [
+                    "style-?sheet(s)?",
+                    "style sheet$1"
+                ],
+                [
+                    "user-?base",
+                    "user base"
+                ],
+                [
+                    "web-?page(s)?",
+                    "web page$1"
+                ],
+                [
+                    "built ?in(s)?",
+                    "built-in$1"
+                ],
+                [
+                    "client ?side",
+                    "client-side"
+                ],
+                [
+                    "end ?to ?end",
+                    "end-to-end"
+                ],
+                [
+                    "end[- ]?2[- ]?end",
+                    "end-to-end"
+                ],
+                [
+                    "error ?prone",
+                    "error-prone"
+                ],
+                [
+                    "higher ?order",
+                    "higher-order"
+                ],
+                [
+                    "key[/ ]?value",
+                    "key-value"
+                ],
+                [
+                    "one ?liner(s)?",
+                    "one-liner$1"
+                ],
+                [
+                    "server ?side",
+                    "server-side"
+                ],
+                [
+                    "two ?steps? authentication",
+                    "two-step authentication"
+                ],
+                [
+                    "two ?steps? verification",
+                    "two-step verification"
+                ],
+                [
+                    "2 ?steps? authentication",
+                    "two-step authentication"
+                ],
+                [
+                    "2 ?steps? verification",
+                    "two-step verification"
+                ],
+                [
+                    "3rd[- ]party",
+                    "third-party"
+                ],
+                [
+                    "(?<=(?:\\w+[^.?!])? )base64\\b",
+                    "base64"
+                ],
+                [
+                    "(?<=(?:\\w+[^.?!])? )internet\\b(?! explorer)",
+                    "internet"
+                ],
+                [
+                    "(?<=(?:\\w+[^.?!])? )stylelint\\b",
+                    "stylelint"
+                ],
+                [
+                    "(?<=(?:\\w+[^.?!])? )webpack\\b",
+                    "webpack"
+                ],
+                [
+                    "(?<=(?:\\w+[^.?!])? )npm\\b",
+                    "npm"
+                ],
+                [
+                    "environemnt(s)?",
+                    "environment$1"
+                ],
+                [
+                    "flacky test(s)?",
+                    "flaky test$1"
+                ],
+                [
+                    "pacakge(s)?",
+                    "package$1"
+                ],
+                [
+                    "tilda",
+                    "tilde"
+                ],
+                [
+                    "falsey",
+                    "falsy"
+                ]
+            ]
+        }
+    }
+}

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -27,5 +27,6 @@ jobs:
         uses: super-linter/super-linter@latest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          VALIDATE_JSON_PRETTIER: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,17 @@
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/*.code-snippets
+
 *.code-workspace
 
 # Local History for Visual Studio Code
 .history/*
 
-# The Powershell build outputs folder
+# PSModule framework outputs folder
 outputs/*
+
+# .Net build output
+bin/
+obj/
+libs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PSModule
+Copyright (c) 2025 PSModule
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tmp/dmp.ps1
+++ b/tmp/dmp.ps1
@@ -1,4 +1,23 @@
 ﻿function Add-EnvPath {
+    <#
+        .SYNOPSIS
+        Adds a path to the PATH environment variable.
+
+        .DESCRIPTION
+        Adds a path to the PATH environment variable for the current session and optionally for the machine or user.
+
+        .EXAMPLE
+        Add-EnvPath -Path 'C:\Program Files\Git\cmd'
+
+        Adds 'C:\Program Files\Git\cmd' to the PATH environment variable for the current session.
+
+        .EXAMPLE
+        Add-EnvPath -Path 'C:\Program Files\Git\cmd' -Container Machine
+
+        Adds 'C:\Program Files\Git\cmd' to the PATH environment variable for the machine.
+
+    #>
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
         [string] $Path,


### PR DESCRIPTION
## Description

This pull request includes several changes focused on updating linter configurations, modifying a workflow, and updating the license year. The most important changes are listed below:

Linter configuration updates:

* [`.github/linters/.jscpd.json`](diffhunk://#diff-557094e283c00b23265c1c75872f41c6b1a524a00f0d99dd68ebd22cb63bfdd6R1-R10): Added a new configuration file for JSCPD (JavaScript Copy/Paste Detector) with a threshold of 0, consoleFull reporter, and ignoring test files.
* [`.github/linters/.powershell-psscriptanalyzer.psd1`](diffhunk://#diff-aae69c9d6774628ed181eacf53aee0f38eb6c2f53492cf3a5b7f7bdb6ef43b6aL1-L16): Updated the PSScriptAnalyzer configuration to enable specific rules and set rule parameters for PowerShell script analysis.

Workflow modification:

* [`.github/workflows/Linter.yml`](diffhunk://#diff-482e65806ed9e4a7320f14964764086b91fed4a28d12e4efde1776472e147e79R30): Disabled JSON Prettier validation by setting `VALIDATE_JSON_PRETTIER` to false.

License update:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year from 2024 to 2025.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
