### PR TITLE
🪲 [Fix]: Fix nightly run to include `SkipTests`

### DIFF
--- a/.github/workflows/Nightly-Run.yml
+++ b/.github/workflows/Nightly-Run.yml
@@ -14,3 +14,5 @@ jobs:
   Process-PSModule:
     uses: PSModule/Process-PSModule/.github/workflows/CI.yml@v4
     secrets: inherit
+    with:
+      SkipTests: Linux, macOS


### PR DESCRIPTION
## Description

This pull request includes a change to the `.github/workflows/Nightly-Run.yml` file to modify the behavior of the `Process-PSModule` job by skipping tests on Linux and macOS platforms.

* [`.github/workflows/Nightly-Run.yml`](diffhunk://#diff-ae7e03d0a8740974e1848d0dc7322a8b3f3f4898b37bfd5b226dff69096bb8dfR17-R18): Added `SkipTests` parameter to the `Process-PSModule` job to skip tests on Linux and macOS.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
