### PR TITLE
🩹 [Patch]: Add PSModule configuration, skipping tests on MacOS and Linux

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -1,0 +1,8 @@
+Name: PSModuleTest
+Test:
+  Linux:
+    Skip: true
+  MacOS:
+    Skip: true
+  CodeCoverage:
+    PercentTarget: 80

--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -28,5 +28,3 @@ jobs:
   Process-PSModule:
     uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v4
     secrets: inherit
-    with:
-      SkipTests: Linux, macOS


### PR DESCRIPTION
## Description

This pull request includes changes to the GitHub Actions workflows to configure and manage the testing of the PSModule. The most important changes involve setting up the PSModule test configuration and updating the workflow to skip tests on specific operating systems.

Configuration of PSModule tests:

* [`.github/PSModule.yml`](diffhunk://#diff-928165ed381f1982eb8f9746a59a2829db4abc8a28eddb8c109e12bb033ff96aR1-R8): Added a new configuration file for PSModule tests, specifying that tests should be skipped on Linux and MacOS, and setting a code coverage target of 80%.

Workflow updates:

* [`.github/workflows/Process-PSModule.yml`](diffhunk://#diff-b4dbaea65a86cef96799e9783b18b31e96a456d476805312f52919d45a060603L31-L32): Removed the `SkipTests` parameter from the workflow configuration, as the skipping of tests is now handled in the PSModule test configuration file.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
